### PR TITLE
Add instagram reels scraper project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+backend/state/
+backend/output/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# insta-scraper
+# Instagram Reels Scraper
+
+This project provides a simple FastAPI backend with a Next.js frontend for scraping Instagram Reels metadata.
+
+## Setup
+
+1. Install Node and Python dependencies:
+   ```bash
+   pnpm install
+   pip install -r backend/requirements.txt
+   playwright install
+   ```
+2. Copy `.env.example` to `.env` under `backend/` and fill your Instagram credentials.
+
+## Running
+
+Start both backend and frontend with:
+
+```bash
+pnpm dev
+```
+
+Open <http://localhost:3000> to access the form.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+INSTA_USER=your_username
+INSTA_PASS=your_password
+WAIT_SEC=0.5

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,45 @@
+import uuid
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import FastAPI, BackgroundTasks, HTTPException
+from fastapi.responses import FileResponse
+from loguru import logger
+
+from scraper.fetch import scrape_job
+
+app = FastAPI()
+
+PROGRESS: Dict[str, Dict] = {}
+
+
+@app.post("/scrape")
+async def start_scrape(data: Dict, background: BackgroundTasks):
+    usernames: List[str] = data.get("usernames", [])
+    hashtags: List[str] = data.get("hashtags", [])
+    max_items: int = data.get("max_items", 10)
+    columns: List[str] = data.get("columns", [])
+
+    job_id = uuid.uuid4().hex
+    background.add_task(scrape_job, job_id, usernames, hashtags, max_items, columns, PROGRESS)
+    PROGRESS[job_id] = {"progress": 0, "status": "queued"}
+    return {"job_id": job_id}
+
+
+@app.get("/progress/{job_id}")
+async def get_progress(job_id: str):
+    if job_id not in PROGRESS:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return PROGRESS[job_id]
+
+
+@app.get("/download/{job_id}")
+async def download(job_id: str):
+    info = PROGRESS.get(job_id)
+    if not info or info.get("status") != "done":
+        raise HTTPException(status_code=404, detail="Not ready")
+    path = Path(info["path"])
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="File missing")
+    filename = f"instagram_reels_{path.stat().st_mtime_ns}.csv"
+    return FileResponse(path, media_type="text/csv", filename=filename)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+playwright
+pandas
+httpx
+loguru
+python-dotenv

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/scraper/__init__.py
+++ b/backend/scraper/__init__.py
@@ -1,0 +1,2 @@
+"""Instagram scraper package."""
+

--- a/backend/scraper/csv_utils.py
+++ b/backend/scraper/csv_utils.py
@@ -1,0 +1,14 @@
+from typing import List, Dict
+import pandas as pd
+
+DEFAULT_COLUMNS = ["url", "title", "caption", "posted_at"]
+
+
+def build_dataframe(data: List[Dict], columns: List[str]) -> pd.DataFrame:
+    """Build pandas DataFrame with default and optional columns."""
+    cols = DEFAULT_COLUMNS + [col for col in columns if col not in DEFAULT_COLUMNS]
+    df = pd.DataFrame(data)
+    for col in cols:
+        if col not in df:
+            df[col] = None
+    return df[cols]

--- a/backend/scraper/fetch.py
+++ b/backend/scraper/fetch.py
@@ -1,0 +1,58 @@
+import random
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+from loguru import logger
+from playwright.sync_api import sync_playwright
+
+from .login import load_context, WAIT_SEC
+from .csv_utils import build_dataframe
+
+
+def scrape_job(job_id: str, usernames: List[str], hashtags: List[str], max_items: int, columns: List[str], progress: Dict[str, Dict]):
+    """Simulate scraping job."""
+    logger.info("Starting scrape job {}", job_id)
+    progress[job_id] = {"progress": 0, "status": "running"}
+
+    results = []
+    total_tasks = len(usernames) + len(hashtags)
+    count = 0
+
+    with sync_playwright() as p:
+        browser, context = load_context(p)
+        page = context.new_page()
+        for user in usernames:
+            logger.info("Scraping user {}", user)
+            time.sleep(random.uniform(WAIT_SEC, WAIT_SEC * 2))
+            results.append({
+                "url": f"https://instagram.com/reel/{user}",
+                "title": user,
+                "caption": f"Sample caption for {user}",
+                "posted_at": int(time.time())
+            })
+            count += 1
+            progress[job_id]["progress"] = int(100 * count / total_tasks)
+
+        for tag in hashtags:
+            logger.info("Scraping hashtag {}", tag)
+            time.sleep(random.uniform(WAIT_SEC, WAIT_SEC * 2))
+            results.append({
+                "url": f"https://instagram.com/reel/{tag}",
+                "title": tag,
+                "caption": f"Sample caption for #{tag}",
+                "posted_at": int(time.time())
+            })
+            count += 1
+            progress[job_id]["progress"] = int(100 * count / total_tasks)
+
+        browser.close()
+
+    df = build_dataframe(results, columns)
+    out_dir = Path("backend/output")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / f"{job_id}.csv"
+    df.to_csv(csv_path, index=False)
+    progress[job_id].update({"status": "done", "path": str(csv_path)})
+    logger.info("Job {} complete", job_id)

--- a/backend/scraper/login.py
+++ b/backend/scraper/login.py
@@ -1,0 +1,49 @@
+import json
+import os
+from pathlib import Path
+from time import sleep
+
+from dotenv import load_dotenv
+from loguru import logger
+from playwright.sync_api import sync_playwright
+
+STATE_PATH = Path("state/insta_state.json")
+
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+
+USER = os.getenv("INSTA_USER")
+PASS = os.getenv("INSTA_PASS")
+WAIT_SEC = float(os.getenv("WAIT_SEC", "0.5"))
+
+
+def login() -> None:
+    """Log into Instagram and save authenticated state."""
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        context = browser.new_context(
+            locale="en-US",
+            extra_http_headers={"Accept-Language": "en-US"},
+        )
+        page = context.new_page()
+        logger.info("Logging into Instagram")
+        page.goto("https://www.instagram.com/accounts/login/")
+        page.fill("input[name=username]", USER)
+        page.fill("input[name=password]", PASS)
+        page.click("button[type=submit]")
+        sleep(WAIT_SEC * 5)
+        context.storage_state(path=STATE_PATH)
+        logger.info("Saved login state to {}", STATE_PATH)
+        browser.close()
+
+
+def load_context(playwright):
+    if not STATE_PATH.exists():
+        login()
+    browser = playwright.chromium.launch(headless=False)
+    context = browser.new_context(
+        locale="en-US",
+        extra_http_headers={"Accept-Language": "en-US"},
+        storage_state=STATE_PATH,
+    )
+    return browser, context

--- a/backend/tests/test_scrape.py
+++ b/backend/tests/test_scrape.py
@@ -1,0 +1,16 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scraper.login import login, load_context
+
+@pytest.mark.skipif(not os.getenv('INSTA_USER'), reason='No credentials')
+def test_login_playwright():
+    from playwright.sync_api import sync_playwright
+    login()
+    with sync_playwright() as p:
+        browser, context = load_context(p)
+        assert context is not None
+        browser.close()

--- a/frontend/app/api/download/[job_id]/route.ts
+++ b/frontend/app/api/download/[job_id]/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(req: NextRequest, { params }: { params: { job_id: string } }) {
+  const res = await fetch(`http://localhost:8000/download/${params.job_id}`)
+  const blob = await res.blob()
+  return new Response(blob, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename=instagram_reels_${params.job_id}.csv`,
+    },
+  })
+}

--- a/frontend/app/api/progress/[job_id]/route.ts
+++ b/frontend/app/api/progress/[job_id]/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest, { params }: { params: { job_id: string } }) {
+  const res = await fetch(`http://localhost:8000/progress/${params.job_id}`)
+  const json = await res.json()
+  return NextResponse.json(json)
+}

--- a/frontend/app/api/scrape/route.ts
+++ b/frontend/app/api/scrape/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const res = await fetch('http://localhost:8000/scrape', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  const json = await res.json()
+  return NextResponse.json(json)
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,10 @@
+import ScrapeForm from '../components/ScrapeForm'
+
+export default function Page() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl mb-4">Instagram Reels Scraper</h1>
+      <ScrapeForm />
+    </main>
+  )
+}

--- a/frontend/app/result/page.tsx
+++ b/frontend/app/result/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import ProgressBar from '../../components/ProgressBar'
+import DownloadCard from '../../components/DownloadCard'
+import { checkProgress } from '../../services/api'
+
+export default function ResultPage() {
+  const params = useSearchParams()
+  const jobId = params.get('job_id') || ''
+  const [progress, setProgress] = useState(0)
+  const [status, setStatus] = useState('running')
+
+  useEffect(() => {
+    if (!jobId) return
+    const interval = setInterval(async () => {
+      const data = await checkProgress(jobId)
+      if (data) {
+        setProgress(data.progress)
+        setStatus(data.status)
+        if (data.status === 'done') clearInterval(interval)
+      }
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [jobId])
+
+  return (
+    <div className="p-4">
+      {status === 'done' ? (
+        <DownloadCard jobId={jobId} />
+      ) : (
+        <ProgressBar progress={progress} />
+      )}
+    </div>
+  )
+}

--- a/frontend/components/DownloadCard.tsx
+++ b/frontend/components/DownloadCard.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { saveAs } from 'file-saver'
+import { useEffect } from 'react'
+import { downloadResult } from '../services/api'
+
+export default function DownloadCard({ jobId }: { jobId: string }) {
+  const handleDownload = async () => {
+    const blob = await downloadResult(jobId)
+    saveAs(blob, `instagram_reels_${jobId}.csv`)
+  }
+
+  useEffect(() => {
+    handleDownload()
+  }, [])
+
+  return (
+    <div className="p-4 border">
+      <button className="px-4 py-2 bg-green-500 text-white" onClick={handleDownload}>
+        Download CSV
+      </button>
+    </div>
+  )
+}

--- a/frontend/components/ProgressBar.tsx
+++ b/frontend/components/ProgressBar.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function ProgressBar({ progress }: { progress: number }) {
+  return (
+    <div className="w-full bg-gray-200 h-4 rounded">
+      <div
+        className="bg-green-500 h-4 rounded"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  )
+}

--- a/frontend/components/ScrapeForm.tsx
+++ b/frontend/components/ScrapeForm.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import { startScrape } from '../services/api'
+
+export default function ScrapeForm() {
+  const [usernames, setUsernames] = useState('')
+  const [hashtags, setHashtags] = useState('')
+  const [maxItems, setMaxItems] = useState(10)
+  const [columns, setColumns] = useState<string[]>([])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await startScrape({
+      usernames: usernames.split('\n').filter(Boolean),
+      hashtags: hashtags.split(',').map(h => h.trim()).filter(Boolean),
+      max_items: maxItems,
+      columns,
+    })
+    if (res?.job_id) {
+      window.location.href = `/result?job_id=${res.job_id}`
+    }
+  }
+
+  const toggleColumn = (col: string) => {
+    setColumns(cols =>
+      cols.includes(col) ? cols.filter(c => c !== col) : [...cols, col]
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <textarea
+        className="w-full border p-2"
+        rows={4}
+        placeholder="Usernames, one per line"
+        value={usernames}
+        onChange={e => setUsernames(e.target.value)}
+      />
+      <input
+        className="w-full border p-2"
+        placeholder="hashtag1, hashtag2"
+        value={hashtags}
+        onChange={e => setHashtags(e.target.value)}
+      />
+      <input
+        type="number"
+        className="w-full border p-2"
+        value={maxItems}
+        onChange={e => setMaxItems(Number(e.target.value))}
+      />
+      <div>
+        {['likes', 'comments', 'video_view_count'].map(col => (
+          <label key={col} className="mr-4">
+            <input
+              type="checkbox"
+              checked={columns.includes(col)}
+              onChange={() => toggleColumn(col)}
+            />{' '}
+            {col}
+          </label>
+        ))}
+      </div>
+      <button className="px-4 py-2 bg-blue-500 text-white" type="submit">
+        Start Scraping
+      </button>
+    </form>
+  )
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.x",
+    "react": "18.x",
+    "react-dom": "18.x",
+    "tailwindcss": "^3.0.0",
+    "file-saver": "^2.0.5"
+  },
+  "devDependencies": {
+    "postcss": "^8.0.0",
+    "autoprefixer": "^10.0.0"
+  }
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,0 +1,21 @@
+export async function startScrape(data: any) {
+  const res = await fetch('/api/scrape', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function checkProgress(jobId: string) {
+  const res = await fetch(`/api/progress/${jobId}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function downloadResult(jobId: string) {
+  const res = await fetch(`/api/download/${jobId}`)
+  if (!res.ok) throw new Error('Download failed')
+  return res.blob()
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tests/ScrapeForm.test.tsx
+++ b/frontend/tests/ScrapeForm.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react'
+import ScrapeForm from '../components/ScrapeForm'
+
+test('renders form', () => {
+  const { getByText } = render(<ScrapeForm />)
+  expect(getByText('Start Scraping')).toBeInTheDocument()
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "instagram-reels-scraper",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"pnpm --filter frontend dev\" \"python backend/run.py\""
+  },
+  "devDependencies": {
+    "concurrently": "^7.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize FastAPI backend with Playwright login and scrape stubs
- add Next.js frontend with form, progress page, and download card
- add basic tests and gitignore

## Testing
- `pytest -q` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e28f9aa6c832fbb18ed92855b0b22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an Instagram Reels Scraper with a FastAPI backend and Next.js frontend.
  * Added user interface for submitting usernames, hashtags, and scraping options.
  * Enabled asynchronous scraping jobs with real-time progress tracking and CSV download.
  * Provided endpoints for job creation, progress monitoring, and result retrieval.
  * Included authentication automation for Instagram login.

* **Bug Fixes**
  * Not applicable.

* **Documentation**
  * Rewrote README with setup instructions and project overview.
  * Added an example environment configuration file.

* **Tests**
  * Added backend and frontend tests to verify login functionality and form rendering.

* **Chores**
  * Added configuration files for environment variables, dependencies, and ignored files.
  * Set up project scripts for streamlined development and concurrent backend/frontend startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->